### PR TITLE
Add footer notice with dynamic SVG

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,6 +211,28 @@
       font-weight: bold;
       color: #25193e;
     }
+
+    .old-experience-notice {
+      text-align: center;
+      padding: 10px;
+      font-size: 0.9em;
+      color: #333;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      background: white;
+      border-top: 1px solid #ddd;
+    }
+
+    .old-experience-notice svg {
+      vertical-align: middle;
+      margin-right: 4px;
+    }
+
+    .container {
+      padding-bottom: 50px;
+    }
   </style>
 </head>
 <body>
@@ -259,8 +281,15 @@
       </div>
 
     </div>
+    </div>
   </div>
-  
+
+  <footer id="oldExperienceNotice" class="old-experience-notice">
+    <span id="newExpIconContainer"></span>
+    This is the old experience, for the newest experience,
+    <a href="https://egg-timer.github.io/App-New/">click here.</a>
+  </footer>
+
   <script>
     const timeMap = {
       soft: 300,
@@ -306,6 +335,15 @@
           notificationWarning.classList.remove("hidden");
         }
       }
+
+      // Load and recolor the new experience icon
+      fetch('new exp.svg')
+        .then(res => res.text())
+        .then(svgText => {
+          svgText = svgText.replace(/fill="#[0-9a-fA-F]{3,6}"/g, 'fill="#000000"');
+          document.getElementById('newExpIconContainer').innerHTML = svgText;
+        })
+        .catch(err => console.error('Error loading SVG:', err));
     });
 
     softnessSelect.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- make the old experience notice a fixed footer
- pad container so content isn't hidden
- recolor SVG icon using a global replace

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d991ff648832581886a58ae8c91ac